### PR TITLE
Fix terminating even though there is a message in queue.

### DIFF
--- a/aiosip/dialog.py
+++ b/aiosip/dialog.py
@@ -434,7 +434,7 @@ class InviteDialog(DialogBase):
 
     async def wait_for_terminate(self, timeout=10):
         try:
-            while not self._waiter.done():
+            while not (self._waiter.done() and self._queue.empty()):
                 yield await asyncio.wait_for(self._queue.get(), timeout)
         except asyncio.TimeoutError:
             LOG.warning("Timeout during wait a response from the server")

--- a/aiosip/protocol.py
+++ b/aiosip/protocol.py
@@ -28,7 +28,6 @@ class UDP(asyncio.DatagramProtocol):
             self.transport.sendto(msg.encode(), addr)
 
     def connection_lost(self, error):
-        LOG.error("Connection lost %s", error)
         self.app._connection_lost(self)
 
     def connection_made(self, transport):

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ test_requirements = [
 
 setup(
     name='aiosip',
-    version='0.2.2',
+    version='0.2.3',
     description='SIP support for AsyncIO',
     long_description=readme + '\n\n' + history,
     author='Ludovic Gasc (GMLudo)',


### PR DESCRIPTION
There is possibility that the queue has [100, 101, 180, 200] if the messages come too faster than consuming the messages. In this case, self._waiter.done() is already True and the last message will be 100 or 101 (not 200). This PR fixed the problem to let the message consumer to consume all messages. 