### PR TITLE
[EEPD-30425] Support empty quoted name

### DIFF
--- a/aiosip/contact.py
+++ b/aiosip/contact.py
@@ -17,7 +17,7 @@ CONTACT_PATTERNS = [
                '[ \t]*'
                '(?:;(?P<params>[^\?]*))?'),
     # quoted name
-    re.compile('^(?:"(?P<name>[^"]+)")'
+    re.compile('^(?:"(?P<name>[^"]*)")'
                '[ \t]*'
                '<(?P<uri>[^>]+)>'
                '[ \t]*'

--- a/tests/test_contact_parsing.py
+++ b/tests/test_contact_parsing.py
@@ -59,6 +59,20 @@ def test_header_with_quoted_name_and_space_before_params():
     assert str(header) == '"Bob" <sips:bob@biloxi.com>;tag=a48s'
 
 
+def test_header_with_quoted_empty_name():
+    header = aiosip.Contact.from_header('""<sip:biloxi.com>')
+    assert header['name'] == ''
+    assert dict(header['params']) == {}
+    assert dict(header['uri']) == {'scheme': 'sip',
+                                   'user': None,
+                                   'password': None,
+                                   'host': 'biloxi.com',
+                                   'port': None,
+                                   'params': None,
+                                   'headers': None}
+    assert str(header) == '<sip:biloxi.com>'
+
+
 def test_header_without_brackets():
     # RFC 3261 - 8.1.1.3
     header = aiosip.Contact.from_header('sip:+12125551212@phone2net.com;tag=887s')


### PR DESCRIPTION
[EEPD-30425](https://eagleeyenetworks.atlassian.net/browse/EEPD-30425)
Digital Acoustics sends the below contact payload:
```
""<sip:10.143.223.161>
```

Full data is:
```
OPTIONS sip:talkdown SIP/2.0
Via: SIP/2.0/UDP 10.143.223.161:5060;branch=z9hG4bKf5297ef6d772b6941d4c5631c65da7d8;rport
Allow: INVITE, OPTIONS, ACK, BYE, CANCEL
CSeq: 10016 OPTIONS
Call-ID: 548325b554b395d6afbd9af52c463ca6@10.143.223.161
Contact: "" <sip:@10.143.223.161:5060>
Content-Length: 0
From: ""<sip:10.143.223.161>;tag=548325b554b395d6afbd9af52c463ca6
Max-Forwards: 70
Supported: replaces
To: ""<sip:10.143.223.161>
User-Agent: Digital Acoustics SR7 V2.0.0.10
```

[EEPD-30425]: https://eagleeyenetworks.atlassian.net/browse/EEPD-30425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ