### PR TITLE
Add Compass component config (compass.yml)

### DIFF
--- a/compass.yml
+++ b/compass.yml
@@ -1,0 +1,8 @@
+name: aiosip
+id: ari:cloud:compass:4337fc0d-aa55-4ff9-bd75-ef7117ff9381:component/4c6fdffe-fa4a-46ef-9e6f-a1aa05480c89/e8f909b0-3438-4c46-b47f-460de0da086a
+configVersion: 1
+typeId: LIBRARY
+ownerId: ari:cloud:identity::team/02623aed-f05b-4acd-8187-7932552722de-14 # Reports (310)
+links:
+  - type: REPOSITORY
+    url: https://github.com/EENCloud/aiosip


### PR DESCRIPTION
Onboards `aiosip` to Compass (replaces the stale compass-github-importer PR).

- typeId: `LIBRARY`
- owner: Reports (310)
- component: `e8f909b0-3438-4c46-b47f-460de0da086a`