### PR TITLE
CODEOWNERS: owning team Reports (310)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# CODEOWNERS — default owner is the repository's owning team.
+# Managed by EngOps (scripts/sync-codeowners.js). Team: Reports (310).
+* @EENCloud/reports-310


### PR DESCRIPTION
Ensures **aiosip** has a CODEOWNERS file naming its owning team **Reports (310)** (`@EENCloud/reports-310`).

**Changes:** create .github/CODEOWNERS (@EENCloud/reports-310)

_Opened by `scripts/sync-codeowners.js` (EngOps). The owning team comes from `truths/repositories.json` → `truths/teams.json`._
