### PR TITLE
fix(compass): add/correct slug fields

### DIFF
--- a/compass.yml
+++ b/compass.yml
@@ -1,5 +1,6 @@
 name: aiosip
 id: ari:cloud:compass:4337fc0d-aa55-4ff9-bd75-ef7117ff9381:component/4c6fdffe-fa4a-46ef-9e6f-a1aa05480c89/e8f909b0-3438-4c46-b47f-460de0da086a
+slug: aiosip
 configVersion: 1
 typeId: LIBRARY
 ownerId: ari:cloud:identity::team/02623aed-f05b-4acd-8187-7932552722de-14 # Reports (310)


### PR DESCRIPTION
## Summary

Adds or corrects `slug:` fields in compass.yml file(s). The slug is derived from the component `name:` field, kebab-cased — the canonical form Compass uses internally. Using the name (rather than the repo name) handles monorepos naturally: each component in a repo has its own distinct name and therefore its own unique slug.

- `compass.yml`: add `slug: aiosip`

🤖 Generated by `scripts/fix-compass-slugs.js`